### PR TITLE
Remove node-raphael2 endpoint configuration

### DIFF
--- a/gatus/config.tpl.yaml
+++ b/gatus/config.tpl.yaml
@@ -401,17 +401,6 @@ endpoints:
         description: "Hello <@325623032456413186>, the node-raphael is down!"
         send-on-resolved: true
 
-  - name: node-raphael2
-    group: kubernetes
-    url: "icmp://204.216.214.156"
-    interval: 1m
-    conditions:
-      - "[CONNECTED] == true"
-    alerts:
-      - type: discord
-        description: "Hello <@325623032456413186>, the node-raphael2 is down!"
-        send-on-resolved: true
-
   - name: node-tom
     group: kubernetes
     url: "icmp://129.151.255.181"


### PR DESCRIPTION
The node-raphael2 endpoint configuration was removed as it is no longer needed.