### PR TITLE
refactor(magnetico): simplify and update magnetico configuration

### DIFF
--- a/magnetico/.on-update.sh
+++ b/magnetico/.on-update.sh
@@ -1,3 +1,3 @@
-sudo mkdir -p /mnt/appdata/magnetico/data /mnt/appdata/magnetico/magneticod /mnt/appdata/magnetico/magneticow
+sudo mkdir -p /mnt/appdata/magnetico
 
 docker compose up -d --remove-orphans

--- a/magnetico/docker-compose.yml
+++ b/magnetico/docker-compose.yml
@@ -1,18 +1,12 @@
+version: "3.9"
 services:
-  magneticod:
-    image: boramalper/magneticod:latest
+  tgragnato:
+    image: "ghcr.io/tgragnato/magnetico:latest"
+    container_name: "magnetico"
+    restart: unless-stopped
+    command: "--database=sqlite3:///data/magnetico.sqlite3"
     volumes:
-      - magneticod-data:/root/.local/share/magneticod
-      - magneticod-config:/root/.config/magneticod
-    network_mode: "host"
-    command:
-      - "--indexer-addr=0.0.0.0:1212"
-
-  magneticow:
-    image: boramalper/magneticow:latest
-    volumes:
-      - magneticod-data:/root/.local/share/magneticod
-      - magneticow-config:/root/.config/magneticow
+      - "magnetico-data:/data"
     networks:
       - traefik
     labels:
@@ -31,17 +25,5 @@ volumes:
     driver: local
     driver_opts:
       type: none
-      device: "/mnt/appdata/magnetico/data"
-      o: bind
-  magneticod-config:
-    driver: local
-    driver_opts:
-      type: none
-      device: "/mnt/appdata/magnetico/magneticod"
-      o: bind
-  magneticow-config:
-    driver: local
-    driver_opts:
-      type: none
-      device: "/mnt/appdata/magnetico/magneticow"
+      device: "/mnt/appdata/magnetico"
       o: bind

--- a/magnetico/docker-compose.yml
+++ b/magnetico/docker-compose.yml
@@ -21,7 +21,7 @@ networks:
     external: true
 
 volumes:
-  magneticod-data:
+  magnetico-data:
     driver: local
     driver_opts:
       type: none


### PR DESCRIPTION
The magnetico configuration has been refactored to use a single service, updated to use the latest ghcr.io/tgragnato/magnetico image, and simplified by removing unnecessary volumes and configurations.